### PR TITLE
fix: 解决文件路径编码问题

### DIFF
--- a/backend/src/main/java/com/hienao/openlist2strm/service/OpenlistApiService.java
+++ b/backend/src/main/java/com/hienao/openlist2strm/service/OpenlistApiService.java
@@ -961,6 +961,7 @@ public class OpenlistApiService {
             .pathSegment("d")
             .path(filePath)
             .build()
+            .encode()
             .toUriString();
 
     log.debug("URL构建编码: {}{}d{} -> {}", baseUrl, "d", filePath, result);


### PR DESCRIPTION
部分中文字符没有编码
```
2026-02-10 20:43:15.261 ERROR task-submit-1 --- [c.h.o.service.OpenlistApiService] : 下载文件异常: 犬夜叉 - 第1季 - 第153话：运命は残酷な再会（命中注定的残酷重逢）；1024×768P.ass, 错误: Illegal character in path at index 83: http://192.168.1.177:5244/d/115/media/动漫/犬夜叉（第1季+完结篇+OVA篇1话+剧场版第1-4季+舞台剧1季+漫画56卷全）/犬夜叉 - 第1季；DVDrip版；1024×768P（167话全；163个视频文件+等量的外挂简中字幕；日语音轨）/犬夜叉 - 第1季 - 第153话：运命は残酷な再会（命中注定的残酷重逢）；1024×768P.ass?sign=WEWV67CrFTHOXIlD0VewHfKVZpUBkJVhehncdzcKwz0=:0
        java.lang.IllegalArgumentException: Illegal character in path at index 83: http://192.168.1.177:5244/d/115/media/动漫/犬夜叉（第1季+完结篇+OVA篇1话+剧场版第1-4季+舞台剧1季+漫画56卷全）/犬夜叉 - 第1季；DVDrip版；1024×768P（167话全；163个视频文件+等量的外挂简中字幕；日语音轨）/犬夜叉 - 第1季 - 第153话：运命は残酷な再会（命中注定的残酷重逢）；1024×768P.ass?sign=WEWV67CrFTHOXIlD0VewHfKVZpUBkJVhehncdzcKwz0=:0
        at java.base/java.net.URI.create(URI.java:932)
        at com.hienao.openlist2strm.service.OpenlistApiService.getFileContent(OpenlistApiService.java:384)
        at com.hienao.openlist2strm.service.MediaScrapingService.copyRelatedFiles(MediaScrapingService.java:849)
        at com.hienao.openlist2strm.service.MediaScrapingService.scrapMedia(MediaScrapingService.java:87)
        at com.hienao.openlist2strm.service.TaskExecutionService.executeTaskLogic(TaskExecutionService.java:268)
        at com.hienao.openlist2strm.service.TaskExecutionService.executeTaskSync(TaskExecutionService.java:115)
        at com.hienao.openlist2strm.service.TaskExecutionService.lambda$submitTask$0(TaskExecutionService.java:65)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
        at java.base/java.lang.Thread.run(Thread.java:1583)
        Caused by: java.net.URISyntaxException: Illegal character in path at index 83: http://192.168.1.177:5244/d/115/media/动漫/犬夜叉（第1季+完结篇+OVA篇1话+剧场版第1-4季+舞台剧1季+漫画56卷全）/犬夜叉 - 第1季；DVDrip版；1024×768P（167话全；163个视频文件+等量的外挂简中字幕；日语音轨）/犬夜叉 - 第1季 - 第153话：运命は残酷な再会（命中注定的残酷重逢）；1024×768P.ass?sign=WEWV67CrFTHOXIlD0VewHfKVZpUBkJVhehncdzcKwz0=:0
        at java.base/java.net.URI$Parser.fail(URI.java:2995)
        at java.base/java.net.URI$Parser.checkChars(URI.java:3166)
        at java.base/java.net.URI$Parser.parseHierarchical(URI.java:3248)
        at java.base/java.net.URI$Parser.parse(URI.java:3196)
        at java.base/java.net.URI.<init>(URI.java:645)
  at java.base/java.net.URI.create(URI.java:930)
  ... 9 common frames omitted
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed URL encoding for file names containing special characters, ensuring proper handling of international file names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->